### PR TITLE
Will upload source IP to etcd

### DIFF
--- a/lib/fluent/plugin/filter_process_ucs_syslog.rb
+++ b/lib/fluent/plugin/filter_process_ucs_syslog.rb
@@ -30,6 +30,9 @@ module Fluent::Plugin
     @@externalRestartEvent = "Restart"
     @@internalRestartEvent = "Internal Restart"
 
+    @@etcdHostname = "etcd"
+    @@etcdPort = 2379
+
     def configure(conf)
       super
     end
@@ -205,7 +208,7 @@ module Fluent::Plugin
 
     def getUcsWithRetry(host, queryBody, retries)
       if retries > 5
-        log.error "Unable to login to UCS to get service profile"
+        log.error "Unable to login to UCS"
         raise SecurityError, "Unable to login to UCS"
       end
 
@@ -245,7 +248,7 @@ module Fluent::Plugin
     def updateEtcd(record)
       sourceIp = record[ucsHostNameKey]
 
-      uri = URI.parse("http://etcd:2379/v2/keys/#{sourceIp}")
+      uri = URI.parse("http://#{@@etcdHostName}:#{@@etcdPort}/v2/keys/#{sourceIp}")
       request = Net::HTTP::Put.new(uri)
 
       req_options = {
@@ -262,8 +265,8 @@ module Fluent::Plugin
           record["error"] += "Error updating etcd: Error code: #{response.code} Response: #{response.value}"
         end
       rescue SocketError => se
-        log.error "Error updating etcd: #{se.message}"
-        record["error"] += "Error updating etcd: #{se.message}"
+        log.error "Error updating etcd: SocketError: #{se.message}"
+        record["error"] += "Error updating etcd: SocketError: #{se.message}"
       end
     end
 

--- a/lib/fluent/plugin/filter_process_ucs_syslog.rb
+++ b/lib/fluent/plugin/filter_process_ucs_syslog.rb
@@ -67,6 +67,8 @@ module Fluent::Plugin
         processFaults(record)
       end
 
+      updateEtcd(record)
+
       return record
     end
 
@@ -187,7 +189,7 @@ module Fluent::Plugin
       begin
         serviceProfile = getServiceProfile(record[ucsHostNameKey], chassisNumber, bladeNumber, 1)
       rescue SecurityError => se
-        record["error"] = se.message
+        record["error"] += "Error getting service profile: #{se.message}"
       end
 
       if !serviceProfile.to_s.empty?
@@ -204,7 +206,7 @@ module Fluent::Plugin
     def getUcsWithRetry(host, queryBody, retries)
       if retries > 5
         log.error "Unable to login to UCS to get service profile"
-        raise SecurityError, "Unable to login to UCS to get service profile"
+        raise SecurityError, "Unable to login to UCS"
       end
 
       token = getToken(host)
@@ -238,6 +240,31 @@ module Fluent::Plugin
       end
 
       return token
+    end
+
+    def updateEtcd(record)
+      sourceIp = record[ucsHostNameKey]
+
+      uri = URI.parse("http://etcd:2379/v2/keys/#{sourceIp}")
+      request = Net::HTTP::Put.new(uri)
+
+      req_options = {
+        use_ssl: uri.scheme == "https",
+      }
+
+      begin
+        response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+          http.request(request)
+        end
+
+        if !response.kind_of? Net::HTTPSuccess
+          log.error "Error updating etcd: Error code: #{response.code} Response: #{response.value}"
+          record["error"] += "Error updating etcd: Error code: #{response.code} Response: #{response.value}"
+        end
+      rescue SocketError => se
+        log.error "Error updating etcd: #{se.message}"
+        record["error"] += "Error updating etcd: #{se.message}"
+      end
     end
 
     def callUcsApi(host, body)

--- a/lib/fluent/plugin/filter_process_ucs_syslog.rb
+++ b/lib/fluent/plugin/filter_process_ucs_syslog.rb
@@ -248,7 +248,7 @@ module Fluent::Plugin
     def updateEtcd(record)
       sourceIp = record[ucsHostNameKey]
 
-      uri = URI.parse("http://#{@@etcdHostName}:#{@@etcdPort}/v2/keys/#{sourceIp}")
+      uri = URI.parse("http://#{@@etcdHostname}:#{@@etcdPort}/v2/keys/#{sourceIp}")
       request = Net::HTTP::Put.new(uri)
 
       req_options = {

--- a/test/test_filter_process_ucs_syslog.rb
+++ b/test/test_filter_process_ucs_syslog.rb
@@ -12,7 +12,7 @@ class ProcessUcsSyslog < Test::Unit::TestCase
     CONFIG = %[
         @type process_ucs_syslog
         ucsHostNameKey SyslogSource
-        coloregion SJC2
+        coloregion FakeColo
         domain testDomain
         username testUsername
         passwordFile /etc/password/ucsPassword
@@ -21,7 +21,7 @@ class ProcessUcsSyslog < Test::Unit::TestCase
     BAD_LOGIN_CONFIG = %[
         @type process_ucs_syslog
         ucsHostNameKey SyslogSource
-        coloregion SJC2
+        coloregion FakeColo
         domain testDomain
         username badUsername
         passwordFile /etc/password/ucsPassword
@@ -102,7 +102,7 @@ class ProcessUcsSyslog < Test::Unit::TestCase
         ]
         filtered_records = filter(records)
         assert_equal records[0]['message'], filtered_records[0]['message']
-        assert_equal 'Cisco_UCS:SJC2:org-root/org-T100/ls-testServiceProfile', filtered_records[0]['machineId']
+        assert_equal 'Cisco_UCS:FakeColo:org-root/org-T100/ls-testServiceProfile', filtered_records[0]['machineId']
         assert_equal 'Soft Shutdown', filtered_records[0]['event']
         assert_equal 'begin', filtered_records[0]['stage']
         assert_equal 'event', filtered_records[0]['type']
@@ -140,7 +140,7 @@ class ProcessUcsSyslog < Test::Unit::TestCase
         ]
         filtered_records = filter(records)
         assert_equal records[0]['message'], filtered_records[0]['message']
-        assert_equal 'Cisco_UCS:SJC2:org-root/org-T100/ls-testServiceProfile', filtered_records[0]['machineId']
+        assert_equal 'Cisco_UCS:FakeColo:org-root/org-T100/ls-testServiceProfile', filtered_records[0]['machineId']
         assert_equal '', filtered_records[0]['event']
         assert_equal '', filtered_records[0]['stage']
         assert_equal 'fault', filtered_records[0]['type']
@@ -190,17 +190,17 @@ class ProcessUcsSyslog < Test::Unit::TestCase
         filtered_records = filter(records)
         
         assert_equal records[0]['message'], filtered_records[0]['message']
-        assert_equal 'Cisco_UCS:SJC2:org-root/org-T100/ls-testServiceProfile', filtered_records[0]['machineId']
+        assert_equal 'Cisco_UCS:FakeColo:org-root/org-T100/ls-testServiceProfile', filtered_records[0]['machineId']
         assert_equal "", filtered_records[0]['event']
         assert_equal "", filtered_records[0]['stage']
 
         assert_equal records[1]['message'], filtered_records[1]['message']
-        assert_equal 'Cisco_UCS:SJC2:org-root/org-T100/ls-testServiceProfile', filtered_records[1]['machineId']
+        assert_equal 'Cisco_UCS:FakeColo:org-root/org-T100/ls-testServiceProfile', filtered_records[1]['machineId']
         assert_equal "Internal Restart", filtered_records[1]['event']
         assert_equal "begin", filtered_records[1]['stage']
 
         assert_equal records[2]['message'], filtered_records[2]['message']
-        assert_equal 'Cisco_UCS:SJC2:org-root/org-T100/ls-testServiceProfile', filtered_records[2]['machineId']
+        assert_equal 'Cisco_UCS:FakeColo:org-root/org-T100/ls-testServiceProfile', filtered_records[2]['machineId']
         assert_equal "Internal Restart", filtered_records[2]['event']
         assert_equal "end", filtered_records[2]['stage']
     end
@@ -229,7 +229,7 @@ class ProcessUcsSyslog < Test::Unit::TestCase
         ]
         filtered_records = filter(records)
         assert_equal records[0]['message'], filtered_records[0]['message']
-        assert_equal 'Cisco_UCS:SJC2:org-root/org-T100/ls-testServiceProfile', filtered_records[0]['machineId']
+        assert_equal 'Cisco_UCS:FakeColo:org-root/org-T100/ls-testServiceProfile', filtered_records[0]['machineId']
         assert_equal 'Soft Shutdown', filtered_records[0]['event']
         assert_equal 'begin', filtered_records[0]['stage']
         assert_equal 'event', filtered_records[0]['type']


### PR DESCRIPTION
Addition to everything, it will also attempt to add the source IP to etcd. 
Failure to do so will emit an error message to log.error as well as append to "error" under record.

**Prerequisite:**
fluentd docker container must be in the same docker network as etcd
etcd container must be named etcd
etcd container must open and listen to port 2379 (this is the default port for etcd)

**Testing:**
Ran unit test
See etcd being populated with correct IP
See correct error message when I stopped etcd

**Sample log:**
2018-06-20 04:37:19.529537461 +0000 syslog.local7.info: {"message":"2018-06-20T04:37:19Z ucsmanager-emulator-int tag[1]: : %UCSM-4-INSUFFICIENTLY_EQUIPPED: [F0305][cleared][insufficiently-equipped][sys/chassis-4/blade-7] Fluff fault message from UCS Emulator","SyslogSource":"172.16.8.5","machineId":"Cisco_UCS:INT:org-root/org-T050/ls-SP-T050-MSFT-SLES-03","event":"","stage":"","type":"fault","severity":"cleared","mnemonic":"insufficiently-equipped","device":"sys/chassis-4/blade-7","error":"","coloRegion":"INT","vmName":"colomanager-int"}
_\<stopped etcd\>_
2018-06-20 04:38:19 +0000 [error]: #0 Error updating etcd: Failed to open TCP connection to etcd:2379 (getaddrinfo: Name or service not known)
2018-06-20 04:38:19.529410877 +0000 syslog.local7.info: {"message":"2018-06-20T04:38:19Z ucsmanager-emulator-int tag[1]: : %UCSM-1-EVENT: [A1234567][7654321][transition][ucs-HANATDIT][] []: Fluff event message from UCS Emulator with username ucs-HANATDI","SyslogSource":"172.16.8.5","machineId":"","event":"","stage":"","type":"event","severity":"info","mnemonic":"","device":"",**"error":"Error updating etcd: Failed to open TCP connection to etcd:2379 (getaddrinfo: Name or service not known)"**,"coloRegion":"INT","vmName":"colomanager-int"}

**etcd:**
root@colomanager-int:/home/hana# docker exec -it etcd sh
/ # etcdctl ls /
/172.16.8.5
/ #