### PR TITLE
Added executedBy field to idenitfy if the command was executed by HANA RP

### DIFF
--- a/lib/fluent/plugin/filter_process_ucs_syslog.rb
+++ b/lib/fluent/plugin/filter_process_ucs_syslog.rb
@@ -47,11 +47,14 @@ module Fluent::Plugin
       record["mnemonic"] = ""
       record["device"] = ""
       record["error"] = ""
+      record["executedBy"] = ""
 
       fullUsername = "#{domain}\\#{username}"
       if !record["message"].include? fullUsername
         # Filter out usernames
         record["message"] = record["message"].gsub(/\\[-\w.]+/, "")
+      else
+        record["executedBy"] = fullUsername
       end
 
       # Append machine id if found

--- a/test/test_filter_process_ucs_syslog.rb
+++ b/test/test_filter_process_ucs_syslog.rb
@@ -170,6 +170,7 @@ class ProcessUcsSyslog < Test::Unit::TestCase
         ]
         filtered_records = filter(records)
         assert_equal "2018 Apr 30 18:11:59 UTC: %AUTHPRIV-5-SYSTEM_MSG: New user added with username testDomain\\testUsername - securityd", filtered_records[0]['message']
+        assert_equal "testDomain\\testUsername", filtered_records[0]['executedBy']
     end
 
     def test_filter_no_service_profile


### PR DESCRIPTION
Added executedBy field to idenitfy if the command was executed by HANA RP
This will be used by ColoAdapter to better correlate a powerstate change with an operation.

Work Item: https://msazure.visualstudio.com/One/_workitems/edit/3324831
