### PR TITLE
[HOTFIX] Adding logout before retrying login to prevent user session leak

### DIFF
--- a/lib/fluent/plugin/filter_process_ucs_syslog.rb
+++ b/lib/fluent/plugin/filter_process_ucs_syslog.rb
@@ -217,11 +217,24 @@ module Fluent::Plugin
       
       if !errorCode.to_s.empty?
         log.info "login failed, retry ", retries
+        
+        if File.exist?(@@tokenFile)
+          logoutToken(host, File.read(@@tokenFile)
+        end
+          
         File.delete(@@tokenFile)
         response = getUcsWithRetry(host, queryBody, retries + 1)
       end
 
       return response
+    end
+    
+    def logoutToken(host, token)
+      logoutBody = "<aaaLogout inCookie=\"#{token}\" />"
+      log.info "logging out with body ", logoutBody
+      
+      response = callUcsApi(host, logoutBody)
+      log.info "logging out response ", response
     end
 
     def getToken(host)

--- a/lib/fluent/plugin/filter_process_ucs_syslog.rb
+++ b/lib/fluent/plugin/filter_process_ucs_syslog.rb
@@ -217,6 +217,8 @@ module Fluent::Plugin
       
       if !errorCode.to_s.empty?
         log.info "login failed, retry ", retries
+        puts response.inspect
+        log.info "response: ", response.inspect
         
         if File.exist?(@@tokenFile)
           logoutToken(host, File.read(@@tokenFile)


### PR DESCRIPTION
Problem:
We login, we do a GET request, and if that fails, we login again. We do not logout the first login token, which means after some time, we leak user sessions and reach a maximum limit by UCSM.

Solution:
Before retrying login, logout first, with best effort. Error is ignored because we can't be sure the token was valid when we logged out. Generous logging is applied because this should only happen when the GET request fails (due to token timeout, or unexpected UCSM failure)