### PR TITLE
Avoid using invalid tokens by refreshing tokens

### DIFF
--- a/lib/fluent/plugin/filter_process_ucs_syslog.rb
+++ b/lib/fluent/plugin/filter_process_ucs_syslog.rb
@@ -11,6 +11,8 @@ module Fluent::Plugin
     config_param :passwordFile, :string
 
     @@tokenFile = "/tmp/token"
+    # the epochs have a unit of seconds
+    @@refreshTokenAfterXSeconds = 60*60 # since tokens expire at 2 hours, refresh after 1 hour
 
     @@eventRegex = /%UCSM-\d-([A-Z_]+)/
 
@@ -35,7 +37,6 @@ module Fluent::Plugin
     end
 
     def filter(tag, time, record)
-
       record["machineId"] = ""
       record["event"] = ""
       record["stage"] = ""
@@ -58,6 +59,7 @@ module Fluent::Plugin
       splitMessage = record["message"].split(": ")
       if splitMessage[2] !~ @@eventRegex
         # Did not recognize message, do nothing
+        log.info "Returning record as-is: did not recognize message #{record["message"]}; looking for regex in message: #{@@eventRegex}"
         return record
       end
 
@@ -181,6 +183,7 @@ module Fluent::Plugin
     def determineMachineId(record, regex)
       message = record["message"]
       if message !~ regex
+        log.info "Returning record without BareMetalMachineID info: message #{message} did not match regex #{regex}"
         return
       end
 
@@ -206,19 +209,16 @@ module Fluent::Plugin
 
     def getUcsWithRetry(host, queryBody, retries)
       if retries > 5
-        log.error "Unable to login to UCS"
-        raise SecurityError, "Unable to login to UCS"
+        log.error "Max retries calling UCS reached"
+        raise SecurityError, "Max retries calling UCS reached"
       end
 
       token = getToken(host)
-
       response = callUcsApi(host, queryBody % {token: token})
       errorCode = response[/errorCode="(\d+)"/,1]
-      
+
       if !errorCode.to_s.empty?
-        log.info "login failed, retry ", retries
-        puts response.inspect
-        log.info "response: ", response.inspect
+        log.info "Calling UCS API failed, retry #{retries}; response: #{response.inspect}"
 
         if File.exist?(@@tokenFile)
           logoutToken(host, File.read(@@tokenFile))
@@ -240,16 +240,42 @@ module Fluent::Plugin
     end
 
     def getToken(host)
+      tokenResponse = ""
+      fullUsername = domain + "\\" + username
+      password = getPassword()
+
       if File.exist?(@@tokenFile)
-        token = File.read(@@tokenFile)
-        return token
+        # Example format: 1604697553/058fb963-cf5b-40fc-a1c0-5d713ec2cbad, where 1604697553 is the epoch when the token was generated
+        token = File.read(@@tokenFile).strip
+
+        if token == ""
+          log.info "File does not contain a token; logging into UCS"
+          loginBody = "<aaaLogin inName=\"#{fullUsername}\" inPassword=\"#{password}\"></aaaLogin>"
+          tokenResponse = callUcsApi(host, loginBody)
+        else
+          tokenEpochStr = token[/(\d+)\/.+/,1]
+          age = Time.now.to_i - tokenEpochStr.to_i
+          if age <= @@refreshTokenAfterXSeconds
+            log.info "Existing token will continue being used (not older than #{@@refreshTokenAfterXSeconds} seconds)"
+            return token
+          else
+            log.info "Existing token will be refreshed, as it is #{age} seconds old"
+
+            # aaaRefresh request body documented here: https://www.cisco.com/c/en/us/td/docs/unified_computing/ucs/e/api/guide/b_cimc_api_book/b_cimc_api_book_chapter_010.pdf
+            # response will have a new token, with a new epoch
+            refreshBody = "<aaaRefresh cookie=\"#{token}\" inCookie=\"#{token}\" inName=\"#{fullUsername}\" inPassword=\"#{password}\"></aaaRefresh>"
+            # example response: <aaaRefresh cookie="1604697553/058fb963-cf5b-40fc-a1c0-5d713ec2cbad" response="yes" outCookie="1604699567/27696198-dd82-444d-98c6-0e36a3f927cd" outRefreshPeriod="600" outPriv="admin,read-only" outDomains="" outChannel="noencssl" outEvtChannel="noencssl" outName="ucs-HANATDIT\sa-hanarp"> </aaaRefresh>
+            # once the new token is generated, making calls with the old token will result in error; example: <configResolveDn dn="sys/chassis-1/blade-1" cookie="1607722287/7a0aa294-1d6a-44b6-abc3-15c65b157183" response="yes" errorCode="552" invocationResult="service-unavailable" errorDescr="Authorization required"> </configResolveDn>
+            tokenResponse = callUcsApi(host, refreshBody)
+          end
+        end
+      else
+        log.info "No existing token; logging into UCS"
+        loginBody = "<aaaLogin inName=\"#{fullUsername}\" inPassword=\"#{password}\"></aaaLogin>"
+        tokenResponse = callUcsApi(host, loginBody)
       end
 
-      password = getPassword()
-      fullUsername = domain + "\\" + username
-      loginBody = "<aaaLogin inName=\"#{fullUsername}\" inPassword=\"#{password}\"></aaaLogin>"
-      response = callUcsApi(host, loginBody)
-      token = response[/outCookie="([\w\/-]+)"/,1]
+      token = tokenResponse[/outCookie="([\w\/-]+)"/,1]
 
       File.open(@@tokenFile, "w") do |f|
         f.write(token)

--- a/test/test_filter_process_ucs_syslog.rb
+++ b/test/test_filter_process_ucs_syslog.rb
@@ -27,6 +27,12 @@ class ProcessUcsSyslog < Test::Unit::TestCase
         passwordFile /etc/password/ucsPassword
       ]
 
+    EPOCH_FUTURE = Time.now.to_i + 10000 # put far in future so it doesn't expire
+    VALID_TOKEN = "%d/12345678-abcd-abcd-abcd-123456789000" % EPOCH_FUTURE
+
+    EPOCH_PAST = Time.now.to_i - 10000 # put far in past so it's guaranteed to be detected as old
+    OLD_TOKEN = "%d/87654321-dfff-dfff-dfff-000987654321" % EPOCH_PAST
+
     def create_driver(conf)
         Fluent::Test::Driver::Filter.new(Fluent::Plugin::ProcessUcsSyslog) do
             # for testing
@@ -36,21 +42,23 @@ class ProcessUcsSyslog < Test::Unit::TestCase
 
             def callUcsApi(host, body)
                 if body.delete(' ') == "<aaaLogin inName=\"testDomain\\testUsername\" inPassword=\"testPassword\"></aaaLogin>".delete(' ') && host == "1.1.1.1"
-                    return '<aaaLogin cookie="" response="yes" outCookie="1111111111/12345678-abcd-abcd-abcd-123456789000"> </aaaLogin>'
-                elsif body.delete(' ') == "<configResolveDn cookie=\"1111111111/12345678-abcd-abcd-abcd-123456789000\" dn=\"sys/chassis-4/blade-7\"></configResolveDn>".delete(' ') && (host == "1.1.1.1" || host == "1.1.1.2")
+                    return '<aaaLogin cookie="" response="yes" outCookie="%{token}"> </aaaLogin>' % {token: VALID_TOKEN}
+                elsif body.delete(' ') == "<aaaRefresh cookie=\"#{OLD_TOKEN}\" inCookie=\"#{OLD_TOKEN}\" inName=\"testDomain\\testUsername\" inPassword=\"testPassword\"></aaaRefresh>".delete(' ') && host == "1.1.1.1"
+                    return '<aaaRefresh cookie="%{oldToken}" response="yes" outCookie="%{newToken}" outRefreshPeriod="600" outPriv="admin,read-only" outDomains="" outChannel="noencssl" outEvtChannel="noencssl" outName="ucs-HANATDIT\sa-hanarp"> </aaaRefresh>' % {oldToken: OLD_TOKEN, newToken: VALID_TOKEN}
+                elsif body.delete(' ') == "<configResolveDn cookie=\"#{VALID_TOKEN}\" dn=\"sys/chassis-4/blade-7\"></configResolveDn>".delete(' ') && (host == "1.1.1.1" || host == "1.1.1.2")
                     return '<lsServer assignedToDn="org-root/org-T100/ls-testServiceProfile"/>'
-                elsif body.delete(' ') == "<configResolveDn cookie=\"1111111111/12345678-abcd-abcd-abcd-123456789000\" dn=\"sys/chassis-14/blade-7\"></configResolveDn>".delete(' ') && host == "1.1.1.1"
+                elsif body.delete(' ') == "<configResolveDn cookie=\"#{VALID_TOKEN}\" dn=\"sys/chassis-14/blade-7\"></configResolveDn>".delete(' ') && host == "1.1.1.1"
                     return '<lsServer assignedToDn="org-root/org-T100/ls-testServiceProfile2"/>'
-                elsif body.delete(' ') == "<configResolveDn cookie=\"1111111111/12345678-abcd-abcd-abcd-123456789000\" dn=\"sys/chassis-4/blade-17\"></configResolveDn>".delete(' ') && host == "1.1.1.1"
+                elsif body.delete(' ') == "<configResolveDn cookie=\"#{VALID_TOKEN}\" dn=\"sys/chassis-4/blade-17\"></configResolveDn>".delete(' ') && host == "1.1.1.1"
                     return '<lsServer assignedToDn="org-root/org-T100/ls-testServiceProfile3"/>'
-                elsif body.delete(' ') == "<configResolveDn cookie=\"1111111111/12345678-abcd-abcd-abcd-123456789000\" dn=\"sys/chassis-4/blade-5\"></configResolveDn>".delete(' ') && host == "1.1.1.1"
+                elsif body.delete(' ') == "<configResolveDn cookie=\"#{VALID_TOKEN}\" dn=\"sys/chassis-4/blade-5\"></configResolveDn>".delete(' ') && host == "1.1.1.1"
                     return '<lsServer assignedToDn=""/>'
                 elsif body.delete(' ') == "<aaaLogin inName=\"testDomain\\badUsername\" inPassword=\"testPassword\"></aaaLogin>".delete(' ') && host == "1.1.1.1"
                     return '<aaaLogin cookie="" response="yes" errorCode="551" invocationResult="unidentified-fail" errorDescr="Authentication failed"> </aaaLogin>'
                 elsif body.delete(' ') == "<configResolveDn cookie=\"\" dn=\"sys/chassis-4/blade-9\"></configResolveDn>".delete(' ') && host == "1.1.1.1"
                     return '<configResolveDn errorCode="552" errorDescr="Authorization required"> </configResolveDn>'
                 elsif body.delete(' ') == "<configResolveClass
-                        cookie=\"1111111111/12345678-abcd-abcd-abcd-123456789000\"
+                        cookie=\"#{VALID_TOKEN}\"
                         inHierarchical=\"false\"
                         classId=\"faultInst\">
                         <inFilter>
@@ -262,8 +270,33 @@ class ProcessUcsSyslog < Test::Unit::TestCase
         if File.exist?(@@tokenFile)
             File.delete(@@tokenFile)
         end
+        
         filtered_records = filter(records, BAD_LOGIN_CONFIG)
         assert_equal "", filtered_records[0]['machineId']
-        assert_equal "Error getting service profile: Unable to login to UCS", filtered_records[0]['error']
+        assert_equal "Error getting service profile: Max retries calling UCS reached", filtered_records[0]['error']
+    end
+
+    def test_filter_refresh_login
+        records = [
+            { 
+                "message" => ": 2018 May  3 00:05:36 IST: %UCSM-6-EVENT: [E4195921][8743116][transition][ucs-HANATDIT][] [FSM:BEGIN]: Soft shutdown of server sys/chassis-4/blade-7(FSM:sam:dme:ComputePhysicalSoftShutdown)",
+                "SyslogSource" => "1.1.1.1"
+            }
+        ]
+        File.write(@@tokenFile, OLD_TOKEN)
+
+        filtered_records = filter(records)
+
+        # old token should get refreshed, and still filter record successfully
+        assert_equal '', filtered_records[0]['error']
+        assert_equal records[0]['message'], filtered_records[0]['message']
+        assert_equal 'Cisco_UCS:FakeColo:org-root/org-T100/ls-testServiceProfile', filtered_records[0]['machineId']
+        assert_equal 'soft shutdown', filtered_records[0]['event']
+        assert_equal 'begin', filtered_records[0]['stage']
+        assert_equal 'event', filtered_records[0]['type']
+        assert_equal 'info', filtered_records[0]['severity']
+        assert_equal '', filtered_records[0]['mnemonic']
+        assert_equal '', filtered_records[0]['device']
+        assert_equal VALID_TOKEN, File.read(@@tokenFile)
     end
 end


### PR DESCRIPTION
**Problem:**
The max session limit is sometimes reached because sessions are left to expire, causing an inability to connect to UCS

Previous PR tried to fix this same symptom by logging out sessions when an error occurred: #13 ; however, the logout would fail because an expired token cannot be used (even to logout)

**Solution:**
- Refresh token dependent on epoch from token
- Clarify existing logging with new token approach
- Add new logging around branching and errors
- Separately handle empty token file (which can happen if username/password is wrong)

**Notes:**
- This PR should wait to merge until the corresponding ucsemulator support is done (Azure DevOps)
- If no calls to UCS are made by a fluentd pod for more than 2 hours, the token it had previously used will be expired. (if less than 2 hours, the token can and will be refreshed)
    - This strikes a balance between regions where many syslogs are seen each minute (where using the same token saves retries), and regions where syslogs only come once or twice per hour

**Testing:**
- Unit tests run for this repo
- Refreshing token does not generate new session (tested), and using pre-refresh token returns error (which code will retry)