### PR TITLE
adding condition to use fluent plugin without domain name

### DIFF
--- a/lib/fluent/plugin/filter_process_ucs_syslog.rb
+++ b/lib/fluent/plugin/filter_process_ucs_syslog.rb
@@ -53,11 +53,8 @@ module Fluent::Plugin
       record["device"] = ""
       record["error"] = ""
 
-      if @domain.nil?
-        fullUsername = "#{username}"
-      else
-        fullUsername = "#{domain}\\#{username}"
-      end
+      # Call the function to get the full username
+      fullUsername = get_full_username(@domain, @username)
       
       if !record["message"].include? fullUsername
         # Filter out usernames
@@ -254,11 +251,8 @@ module Fluent::Plugin
     def getToken(host)
       tokenResponse = ""
 
-      if @domain.nil?
-        fullUsername = username
-      else
-        fullUsername = domain + "\\" + username
-      end
+      # Call the function to get the full username
+      fullUsername = get_full_username(@domain, @username)
 
       password = getPassword()
 
@@ -299,6 +293,15 @@ module Fluent::Plugin
         f.write(token)
       end
       return token
+    end
+
+    def get_full_username(domain, username)
+      if domain.nil?
+        fullUsername = username
+      else
+        fullUsername = "#{domain}\\#{username}"
+      end
+      fullUsername
     end
 
     def callUcsApi(host, body)

--- a/lib/fluent/plugin/filter_process_ucs_syslog.rb
+++ b/lib/fluent/plugin/filter_process_ucs_syslog.rb
@@ -37,7 +37,7 @@ module Fluent::Plugin
     def configure(conf)
       super
       if @domain.nil?
-        log.info("Domain not specified, assuming canary environment")
+        log.info("Domain not specified in that scenerio")
       else
         log.info("Using domain: #{@domain}")
       end


### PR DESCRIPTION
We used to include a domain name in username earlier, but now we're not doing that anymore in local account authentication. Instead, we're passing the domain name as a parameter in our Fluent plugin code. To make this change, we need to modify the function so that it doesn't require the domain name anymore. Adding changes for the scenario when we are not passing domain name as config parameter.  

Testing :
I conducted a test by building a new Docker image based on the previous Fluentd image. In this new image, I incorporated some changes to a plugin. I then replaced the original image with this modified one and deployed it in a canary region to verify if it functions as intended.

I added logs to the plugin code to confirm that the recent changes are functioning correctly with the existing code, and I received the expected logs.